### PR TITLE
Settings being dropped after eclipse restart #1

### DIFF
--- a/bundles/ru.zelenyhleb.etape.preferences/src/ru/zelenyhleb/etape/preferences/ui/CopyrightPreferencePage.java
+++ b/bundles/ru.zelenyhleb.etape.preferences/src/ru/zelenyhleb/etape/preferences/ui/CopyrightPreferencePage.java
@@ -41,7 +41,7 @@ public final class CopyrightPreferencePage extends FieldEditorPreferencePage imp
 
 	@Override
 	protected void createFieldEditors() {
-		addField(new StringFieldEditor(new Preferences().copyright().get(),
+		addField(new StringFieldEditor(new Preferences().copyright().key(),
 				Messages.CopyrightPreferencePage_label_copyright, StringFieldEditor.UNLIMITED, 10,
 				StringFieldEditor.VALIDATE_ON_KEY_STROKE, getFieldEditorParent()));
 	}


### PR DESCRIPTION
let `copyright` value be properly editable and visible for both _project template wizard_ and _etape pref page_